### PR TITLE
added actual mock data in timestaps like the leetcode graphql endpoint

### DIFF
--- a/LeetCodeContributionGraph/ContentView.swift
+++ b/LeetCodeContributionGraph/ContentView.swift
@@ -12,45 +12,20 @@ struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var items: [Item]
 
+    private var dayCounts: [Date: Int] {
+        let calendar = Calendar.current
+        var counts: [Date: Int] = [:]
+        for item in items {
+            let dayStart = calendar.startOfDay(for: item.timestamp)
+            counts[dayStart, default: 0] += 1
+        }
+        return counts
+    }
+
     var body: some View {
-        NavigationSplitView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                    } label: {
-                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
-                    }
-                }
-                .onDelete(perform: deleteItems)
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                }
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
-                }
-            }
-        } detail: {
-            Text("Select an item")
-        }
-    }
-
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(timestamp: Date())
-            modelContext.insert(newItem)
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
-            }
+        VStack(spacing: 0) {
+            ContributionGraph(dayCounts: dayCounts)
+                .padding(.top, 8)
         }
     }
 }

--- a/LeetCodeContributionGraph/ContributionGraphViewModel.swift
+++ b/LeetCodeContributionGraph/ContributionGraphViewModel.swift
@@ -1,0 +1,70 @@
+//
+//  ContributionGraphViewModel.swift
+//  LeetCodeContributionGraph
+//
+//  Created by Luis Garcia on 3/18/26.
+//
+
+import SwiftUI
+import Observation
+
+@Observable
+class ContributionGraphViewModel {
+    var grid: [[Int]] = []
+
+    let weeks: Int
+
+    init(dayCounts: [Date: Int], weeks: Int = 16) {
+        self.weeks = weeks
+        self.grid = Self.buildGrid(from: dayCounts, weeks: weeks)
+    }
+
+    func update(dayCounts: [Date: Int]) {
+        grid = Self.buildGrid(from: dayCounts, weeks: weeks)
+    }
+
+    // Grid computation
+
+    // Builds a [week][day] grid where week 0 is the oldest and the last week is the current one (containing today). day 0 = Sunday … day 6 = Saturday (matches Calendar.current weekday ordering).
+    private static func buildGrid(from dayCounts: [Date: Int], weeks: Int) -> [[Int]] {
+        let calendar = Calendar.current
+        let today = Date()
+
+        // Start of the current week (Sunday)
+        guard let currentWeekInterval = calendar.dateInterval(of: .weekOfYear, for: today) else {
+            return Array(repeating: Array(repeating: 0, count: 7), count: weeks)
+        }
+        let startOfCurrentWeek = currentWeekInterval.start
+
+        // The graph starts (weeks - 1) full weeks before the current week
+        guard let graphStart = calendar.date(byAdding: .weekOfYear, value: -(weeks - 1), to: startOfCurrentWeek) else {
+            return Array(repeating: Array(repeating: 0, count: 7), count: weeks)
+        }
+
+        // Populate the grid
+        var grid = Array(repeating: Array(repeating: 0, count: 7), count: weeks)
+        for week in 0..<weeks {
+            for day in 0..<7 {
+                guard let date = calendar.date(byAdding: .day, value: week * 7 + day, to: graphStart) else { continue }
+                // Future cells stay empty
+                if date > today { continue }
+                let dayStart = calendar.startOfDay(for: date)
+                let count = dayCounts[dayStart] ?? 0
+                grid[week][day] = Self.intensityLevel(for: count)
+            }
+        }
+
+        return grid
+    }
+
+    // Maps a raw contribution count to a 0-4 intensity level.
+    private static func intensityLevel(for count: Int) -> Int {
+        switch count {
+        case 0:        return 0
+        case 1:        return 1
+        case 2:        return 2
+        case 3:        return 3
+        default:       return 4
+        }
+    }
+}

--- a/LeetCodeContributionGraph/MockData.swift
+++ b/LeetCodeContributionGraph/MockData.swift
@@ -1,0 +1,80 @@
+//
+//  MockData.swift
+//  LeetCodeContributionGraph
+//
+//  Created by Luis Garcia on 3/18/26.
+//
+
+import Foundation
+
+// LeetCode API Response Models
+
+struct LeetCodeResponse: Codable {
+    let data: LeetCodeData
+}
+
+struct LeetCodeData: Codable {
+    let matchedUser: MatchedUser
+}
+
+struct MatchedUser: Codable {
+    let userCalendar: UserCalendar
+}
+
+struct UserCalendar: Codable {
+    let activeYears: [Int]
+    let streak: Int
+    let totalActiveDays: Int
+    let submissionCalendar: String
+}
+
+// Mock Data
+
+enum MockData {
+    // Raw JSON matching the real LeetCode GraphQL API response format.
+    static let json = """
+    {
+        "data": {
+            "matchedUser": {
+                "userCalendar": {
+                    "activeYears": [2025, 2026],
+                    "streak": 4,
+                    "totalActiveDays": 11,
+                    "dccBadges": [],
+                    "submissionCalendar": "{\\"1767225600\\": 1, \\"1767484800\\": 5, \\"1767571200\\": 1, \\"1767657600\\": 1, \\"1767744000\\": 16, \\"1767916800\\": 1, \\"1772928000\\": 1, \\"1773014400\\": 2, \\"1773100800\\": 1, \\"1773187200\\": 2, \\"1773360000\\": 1}"
+                }
+            }
+        }
+    }
+    """
+
+    // Parses the mock JSON into a `LeetCodeResponse`.
+    static let response: LeetCodeResponse = {
+        let data = Data(json.utf8)
+        return try! JSONDecoder().decode(LeetCodeResponse.self, from: data)
+    }()
+
+    // Parses `submissionCalendar` into a dictionary of `[Date: Int]` (day -> submission count).
+    static let submissionCalendar: [Date: Int] = {
+        parseSubmissionCalendar(response.data.matchedUser.userCalendar.submissionCalendar)
+    }()
+
+    // Converts the `submissionCalendar` JSON string (unix timestamps as keys, counts as values) into a `[Date: Int]` dictionary keyed by the start of each day.
+    static func parseSubmissionCalendar(_ calendarString: String) -> [Date: Int] {
+        guard let data = calendarString.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Int] else {
+            return [:]
+        }
+
+        let calendar = Calendar.current
+        var result: [Date: Int] = [:]
+        for (timestampString, count) in dict {
+            if let timestamp = TimeInterval(timestampString) {
+                let date = Date(timeIntervalSince1970: timestamp)
+                let dayStart = calendar.startOfDay(for: date)
+                result[dayStart, default: 0] += count
+            }
+        }
+        return result
+    }
+}

--- a/LeetCodeContributionGraph/ViewContributionGrpah.swift
+++ b/LeetCodeContributionGraph/ViewContributionGrpah.swift
@@ -8,24 +8,23 @@
 import SwiftUI
 
 struct ContributionGraph: View {
-    let weeks = 16
-    let days = 7
+    @State private var viewModel: ContributionGraphViewModel
+
     let cellSize: CGFloat = 18
     let spacing: CGFloat = 3
 
-    @State private var contributions:
-    [[Int]] = (0..<52).map { _ in
-        (0..<7).map { _ in Int.random(in: 0...4) }
+    init(dayCounts: [Date: Int]) {
+        _viewModel = State(wrappedValue: ContributionGraphViewModel(dayCounts: dayCounts))
     }
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: spacing) {
-                ForEach(0..<weeks, id: \.self) { week in
+                ForEach(0..<viewModel.weeks, id: \.self) { week in
                     VStack(spacing: spacing) {
-                        ForEach(0..<days, id: \.self) { day in
+                        ForEach(0..<7, id: \.self) { day in
                             RoundedRectangle(cornerRadius: 2)
-                                .fill(color(for: contributions[week][day]))
+                                .fill(color(for: viewModel.grid[week][day]))
                                 .frame(width: cellSize, height: cellSize)
                         }
                     }
@@ -59,6 +58,5 @@ extension Color {
 }
 
 #Preview {
-    ContributionGraph()
-
+    ContributionGraph(dayCounts: MockData.submissionCalendar)
 }


### PR DESCRIPTION
This pull request introduces a significant refactor and new features to support a LeetCode-style contribution graph. The main changes include implementing a dedicated view model for the contribution graph, parsing mock LeetCode API data, and updating the UI to use real submission data instead of random values. The code now computes daily submission counts and visualizes them in a grid, closely matching the actual LeetCode contribution graph.

**Contribution Graph Refactor and Feature Additions:**

- Introduced a new `ContributionGraphViewModel` class to handle the computation and transformation of daily submission counts into a grid format suitable for the contribution graph UI. This includes mapping raw counts to intensity levels and supporting dynamic updates.
- Updated the `ContributionGraph` view to use the new view model and accept real `dayCounts` data, replacing the previous random data generation. The UI now accurately reflects actual contribution data.

**Data Handling and Mocking:**

- Added a `MockData` utility with realistic LeetCode API response models, mock JSON data, and logic to parse the submission calendar into a `[Date: Int]` dictionary. This enables previewing and testing the contribution graph with representative data.
- Updated the preview for `ContributionGraph` to use the parsed mock submission calendar data, demonstrating the new data-driven rendering.

**Integration with App State:**

- Refactored `ContentView` to compute a `[Date: Int]` dictionary (`dayCounts`) from the app's `items`, and pass this to the `ContributionGraph` for visualization. The previous list and navigation UI were removed to focus on the contribution graph display.