### PR TITLE
Add URL fetch and hook for LeetCode submission calendar

### DIFF
--- a/LeetCodeContributionGraph/ContentView.swift
+++ b/LeetCodeContributionGraph/ContentView.swift
@@ -6,31 +6,67 @@
 //
 
 import SwiftUI
-import SwiftData
 
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Query private var items: [Item]
+    let username = "LUISJG57"
+    let year = "2025"
 
-    private var dayCounts: [Date: Int] {
-        let calendar = Calendar.current
-        var counts: [Date: Int] = [:]
-        for item in items {
-            let dayStart = calendar.startOfDay(for: item.timestamp)
-            counts[dayStart, default: 0] += 1
-        }
-        return counts
-    }
+    @State private var dayCounts: [Date: Int] = [:]
+    @State private var errorMessage: String?
+    @State private var timer: Timer?
 
     var body: some View {
         VStack(spacing: 0) {
             ContributionGraph(dayCounts: dayCounts)
                 .padding(.top, 8)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding()
+            }
         }
+        .task {
+            await fetchCalendar()
+        }
+        .onAppear {
+            startTimer()
+        }
+        .onDisappear {
+            stopTimer()
+        }
+    }
+
+    // MARK: - Networking
+
+    private func fetchCalendar() async {
+        let year = Calendar.current.component(.year, from: Date())
+        do {
+            let result = try await LeetCodeService.shared.fetchCalendar(username: username, year: year)
+            dayCounts = result
+            errorMessage = nil
+        } catch {
+            errorMessage = "Failed to load: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Auto-refresh timer (every 30 seconds)
+
+    private func startTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { _ in
+            Task {
+                await fetchCalendar()
+            }
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
     }
 }
 
 #Preview {
     ContentView()
-        .modelContainer(for: Item.self, inMemory: true)
 }

--- a/LeetCodeContributionGraph/ContributionGraphViewModel.swift
+++ b/LeetCodeContributionGraph/ContributionGraphViewModel.swift
@@ -5,28 +5,11 @@
 //  Created by Luis Garcia on 3/18/26.
 //
 
-import SwiftUI
-import Observation
+import Foundation
 
-@Observable
-class ContributionGraphViewModel {
-    var grid: [[Int]] = []
-
-    let weeks: Int
-
-    init(dayCounts: [Date: Int], weeks: Int = 16) {
-        self.weeks = weeks
-        self.grid = Self.buildGrid(from: dayCounts, weeks: weeks)
-    }
-
-    func update(dayCounts: [Date: Int]) {
-        grid = Self.buildGrid(from: dayCounts, weeks: weeks)
-    }
-
-    // Grid computation
-
-    // Builds a [week][day] grid where week 0 is the oldest and the last week is the current one (containing today). day 0 = Sunday … day 6 = Saturday (matches Calendar.current weekday ordering).
-    private static func buildGrid(from dayCounts: [Date: Int], weeks: Int) -> [[Int]] {
+enum ContributionGraphViewModel {
+    // Builds a [week][day] grid where week 0 is the oldest and the last week is the current one (containing today). day 0 = Sunday ... day 6 = Saturday.
+    static func buildGrid(from dayCounts: [Date: Int], weeks: Int) -> [[Int]] {
         let calendar = Calendar.current
         let today = Date()
 
@@ -46,11 +29,10 @@ class ContributionGraphViewModel {
         for week in 0..<weeks {
             for day in 0..<7 {
                 guard let date = calendar.date(byAdding: .day, value: week * 7 + day, to: graphStart) else { continue }
-                // Future cells stay empty
                 if date > today { continue }
                 let dayStart = calendar.startOfDay(for: date)
                 let count = dayCounts[dayStart] ?? 0
-                grid[week][day] = Self.intensityLevel(for: count)
+                grid[week][day] = intensityLevel(for: count)
             }
         }
 
@@ -58,13 +40,13 @@ class ContributionGraphViewModel {
     }
 
     // Maps a raw contribution count to a 0-4 intensity level.
-    private static func intensityLevel(for count: Int) -> Int {
+    static func intensityLevel(for count: Int) -> Int {
         switch count {
-        case 0:        return 0
-        case 1:        return 1
-        case 2:        return 2
-        case 3:        return 3
-        default:       return 4
+        case 0:    return 0
+        case 1:    return 1
+        case 2:    return 2
+        case 3:    return 3
+        default:   return 4
         }
     }
 }

--- a/LeetCodeContributionGraph/LeetcodeResponseModel.swift
+++ b/LeetCodeContributionGraph/LeetcodeResponseModel.swift
@@ -1,0 +1,79 @@
+//
+//  LeetcodeResponseModel.swift
+//  LeetCodeContributionGraph
+//
+//  Created by Luis Garcia on 3/21/26.
+//
+
+import Foundation
+
+// MARK: - Response Models
+
+struct LeetCodeResponse: Codable {
+    let data: LeetCodeData
+}
+
+struct LeetCodeData: Codable {
+    let matchedUser: MatchedUser
+}
+
+struct MatchedUser: Codable {
+    let userCalendar: UserCalendar
+}
+
+struct UserCalendar: Codable {
+    let submissionCalendar: String
+}
+
+// MARK: - Service
+
+struct LeetCodeService {
+    static let shared = LeetCodeService()
+
+    /// Fetches the submission calendar for a public LeetCode profile.
+    func fetchCalendar(username: String, year: Int) async throws -> [Date: Int] {
+        let url = URL(string: "https://leetcode.com/graphql/")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("https://leetcode.com", forHTTPHeaderField: "Referer")
+
+        let query = """
+        query userProfileCalendar($username: String!, $year: Int) {
+          matchedUser(username: $username) {
+            userCalendar(year: $year) {
+              submissionCalendar
+            }
+          }
+        }
+        """
+        let body: [String: Any] = [
+            "query": query,
+            "variables": ["username": username, "year": String(year)]
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let decoded = try JSONDecoder().decode(LeetCodeResponse.self, from: data)
+        return Self.parseSubmissionCalendar(decoded.data.matchedUser.userCalendar.submissionCalendar)
+    }
+
+    // Converts the `submissionCalendar` JSON string (unix timestamp keys, count values) into a `[Date: Int]` dictionary keyed by start of day.
+    static func parseSubmissionCalendar(_ calendarString: String) -> [Date: Int] {
+        guard let data = calendarString.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Int] else {
+            return [:]
+        }
+
+        let calendar = Calendar.current
+        var result: [Date: Int] = [:]
+        for (timestampString, count) in dict {
+            if let timestamp = TimeInterval(timestampString) {
+                let date = Date(timeIntervalSince1970: timestamp)
+                let dayStart = calendar.startOfDay(for: date)
+                result[dayStart, default: 0] += count
+            }
+        }
+        return result
+    }
+}

--- a/LeetCodeContributionGraph/MockData.swift
+++ b/LeetCodeContributionGraph/MockData.swift
@@ -5,76 +5,17 @@
 //  Created by Luis Garcia on 3/18/26.
 //
 
+/*
 import Foundation
 
-// LeetCode API Response Models
-
-struct LeetCodeResponse: Codable {
-    let data: LeetCodeData
-}
-
-struct LeetCodeData: Codable {
-    let matchedUser: MatchedUser
-}
-
-struct MatchedUser: Codable {
-    let userCalendar: UserCalendar
-}
-
-struct UserCalendar: Codable {
-    let activeYears: [Int]
-    let streak: Int
-    let totalActiveDays: Int
-    let submissionCalendar: String
-}
-
-// Mock Data
-
 enum MockData {
-    // Raw JSON matching the real LeetCode GraphQL API response format.
-    static let json = """
-    {
-        "data": {
-            "matchedUser": {
-                "userCalendar": {
-                    "activeYears": [2025, 2026],
-                    "streak": 4,
-                    "totalActiveDays": 11,
-                    "dccBadges": [],
-                    "submissionCalendar": "{\\"1767225600\\": 1, \\"1767484800\\": 5, \\"1767571200\\": 1, \\"1767657600\\": 1, \\"1767744000\\": 16, \\"1767916800\\": 1, \\"1772928000\\": 1, \\"1773014400\\": 2, \\"1773100800\\": 1, \\"1773187200\\": 2, \\"1773360000\\": 1}"
-                }
-            }
-        }
-    }
+    /// Raw submissionCalendar string matching the real LeetCode GraphQL API format.
+    static let submissionCalendarJSON = """
+    {"1767225600": 1, "1767484800": 5, "1767571200": 1, "1767657600": 1, "1767744000": 16, "1767916800": 1, "1772928000": 1, "1773014400": 2, "1773100800": 1, "1773187200": 2, "1773360000": 1}
     """
 
-    // Parses the mock JSON into a `LeetCodeResponse`.
-    static let response: LeetCodeResponse = {
-        let data = Data(json.utf8)
-        return try! JSONDecoder().decode(LeetCodeResponse.self, from: data)
-    }()
-
-    // Parses `submissionCalendar` into a dictionary of `[Date: Int]` (day -> submission count).
+    /// Parsed [Date: Int] for use in previews.
     static let submissionCalendar: [Date: Int] = {
-        parseSubmissionCalendar(response.data.matchedUser.userCalendar.submissionCalendar)
+        LeetCodeService.parseSubmissionCalendar(submissionCalendarJSON)
     }()
-
-    // Converts the `submissionCalendar` JSON string (unix timestamps as keys, counts as values) into a `[Date: Int]` dictionary keyed by the start of each day.
-    static func parseSubmissionCalendar(_ calendarString: String) -> [Date: Int] {
-        guard let data = calendarString.data(using: .utf8),
-              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Int] else {
-            return [:]
-        }
-
-        let calendar = Calendar.current
-        var result: [Date: Int] = [:]
-        for (timestampString, count) in dict {
-            if let timestamp = TimeInterval(timestampString) {
-                let date = Date(timeIntervalSince1970: timestamp)
-                let dayStart = calendar.startOfDay(for: date)
-                result[dayStart, default: 0] += count
-            }
-        }
-        return result
-    }
-}
+} */

--- a/LeetCodeContributionGraph/ViewContributionGrpah.swift
+++ b/LeetCodeContributionGraph/ViewContributionGrpah.swift
@@ -8,23 +8,24 @@
 import SwiftUI
 
 struct ContributionGraph: View {
-    @State private var viewModel: ContributionGraphViewModel
+    var dayCounts: [Date: Int]
+    var weeks: Int = 16
 
     let cellSize: CGFloat = 18
     let spacing: CGFloat = 3
 
-    init(dayCounts: [Date: Int]) {
-        _viewModel = State(wrappedValue: ContributionGraphViewModel(dayCounts: dayCounts))
+    private var grid: [[Int]] {
+        ContributionGraphViewModel.buildGrid(from: dayCounts, weeks: weeks)
     }
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: spacing) {
-                ForEach(0..<viewModel.weeks, id: \.self) { week in
+                ForEach(0..<weeks, id: \.self) { week in
                     VStack(spacing: spacing) {
                         ForEach(0..<7, id: \.self) { day in
                             RoundedRectangle(cornerRadius: 2)
-                                .fill(color(for: viewModel.grid[week][day]))
+                                .fill(color(for: grid[week][day]))
                                 .frame(width: cellSize, height: cellSize)
                         }
                     }
@@ -57,6 +58,8 @@ extension Color {
     }
 }
 
+/*
 #Preview {
     ContributionGraph(dayCounts: MockData.submissionCalendar)
 }
+*/


### PR DESCRIPTION
This pull request refactors the contribution graph feature to fetch real LeetCode submission data via a network call, removes the previous local data model, and simplifies the view model logic. The main changes include introducing a network service for fetching and parsing LeetCode data, updating the UI to reflect live data with auto-refresh, and cleaning up unused or obsolete code.

**LeetCode API integration and data fetching:**

* Added a new `LeetCodeService` in `LeetCodeResponseModel.swift` to fetch a user's submission calendar from the LeetCode GraphQL API, parse the response, and convert it into a `[Date: Int]` dictionary.
* Updated `ContentView.swift` to fetch and display live LeetCode contribution data for a given username, handle errors, and auto-refresh every 30 seconds.

**View model and UI simplification:**

* Refactored `ContributionGraphViewModel` to a static utility enum with only pure functions for grid building and intensity calculation, removing all state and observation logic. [[1]](diffhunk://#diff-918963b0c63187ff1a95bfd668970d75f369bc7b8fb4a7a3a64151e8a8011977L8-R12) [[2]](diffhunk://#diff-918963b0c63187ff1a95bfd668970d75f369bc7b8fb4a7a3a64151e8a8011977L49-R43)
* Updated `ContributionGraph` (in `ViewContributionGrpah.swift`) to use the new stateless grid-building logic and accept raw day count data directly, simplifying its interface.

**Cleanup and removal of old code:**

* Removed the old local data model and mock response parsing from `MockData.swift`, keeping only a static mock submission calendar for previews (now commented out).
* Commented out the preview in `ViewContributionGrpah.swift` that relied on the old mock data.